### PR TITLE
New documentation format

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,5 +1,8 @@
-name: DOCS
+name: Documentation
 on:
+  pull_request:
+    branches:
+      - main
   push:
     branches:
       - main
@@ -7,14 +10,11 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
-        ref: main
+        ref: ${{ github.head_ref }}
     - name: Render terraform docs and push changes back to PR
       uses: terraform-docs/gh-actions@main
       with:
-        working-dir: .
-        output-file: README.md
-        output-method: inject
+        config-file: .terraform-docs.yml
         git-push: "true"
-        git-commit-message: "terraform-docs: automated action"

--- a/.terraform-docs.yml
+++ b/.terraform-docs.yml
@@ -1,0 +1,102 @@
+formatter: "markdown"
+
+# Tested with this version
+# As Majorversion is 0 any change may break
+version: ">=0.16.0"
+
+sections:
+  hide:
+    - header
+    - providers
+
+output:
+  file: "README.md"
+  mode: inject
+
+sort:
+  enabled: true
+  by: required
+
+content: |-
+  {{- define "setDict" -}}
+    {{- $resource := list -}}
+    {{- if hasKey .Dict .Key -}}
+      {{- $resource = get .Dict .Key -}}
+    {{- else -}}
+       {{- $resource = list -}}
+    {{- end -}}
+    {{- $resource := append $resource .Resource -}}
+    {{- $_ := set .Dict .Key $resource -}}
+  {{- end -}}
+  
+  {{- $filesResources := dict -}}
+  {{- $resourceTypes := dict -}}
+  {{- range .Module.Resources -}}
+    {{- template "setDict" dict "Dict" $filesResources "Key" .Position.Filename "Resource" . -}}
+    {{- $isResource := eq "resource" (printf "%s" .GetMode) -}}
+    {{- if $isResource -}}
+      {{- template "setDict" dict "Dict" $resourceTypes "Key" (printf "%s_%s" .ProviderName .Type) "Resource" . -}}
+    {{- end -}}
+  {{- end -}}
+
+  {{ indent 0 "#" }} Usage
+
+  It's very easy to use!
+  ```hcl
+  {{ include "examples/basic/main.tf" }}
+  ```
+  
+  {{ .Requirements }}
+  {{ .Providers }}
+  {{ .Inputs }}
+  {{ .Outputs }}
+  {{ if .Config.Sections.Resources -}}
+    {{- if not (keys $resourceTypes) -}}
+        {{- if not .Config.Settings.HideEmpty -}}
+            {{- indent 0 "#" }} Resource types
+
+            No resources.
+        {{ end }}
+      {{ else }}
+        {{ indent 0 "#" }} Resource types
+
+        | Type | Used |
+        |------|-------|
+        {{- range $type,$resources := $resourceTypes }}
+          {{- $url := (first $resources).URL -}}
+          {{- $type = ternary $url (printf "[%s](%s)" $type $url) $type }}
+          | {{ $type }} | {{ len $resources }} |
+        {{- end }}
+
+        **`Used` only includes resource blocks.** `for_each` and `count` meta arguments, as well as resource blocks of modules are not considered.
+      {{ end }}
+  {{ end -}}
+
+  {{ .Modules }}
+  {{ if or .Config.Sections.Resources .Config.Sections.DataSources -}}
+      {{- if not (keys $filesResources) -}}
+          {{- if not .Config.Settings.HideEmpty -}}
+              {{ indent 0 "#" }} Resources by Files
+
+              No resources.
+          {{ end }}
+      {{ else }}
+          {{ indent 0 "#" }} Resources by Files
+          {{- range $fileName,$resources := $filesResources }}
+
+              {{ indent 1 "#" }} {{ $fileName }}
+
+              | Name | Type |
+              |------|------|
+              
+              {{- range $resources -}}
+                {{- $isResource := and $.Config.Sections.Resources ( eq "resource" (printf "%s" .GetMode)) }}
+                {{- $isDataResource := and $.Config.Sections.DataSources ( eq "data source" (printf "%s" .GetMode)) }}
+                {{- if or $isResource $isDataResource }}
+                    {{- $fullspec := ternary .URL (printf "[%s](%s)" .Spec .URL) .Spec }}
+                    | {{ $fullspec }} | {{ .GetMode }} |
+                {{- end }}
+              {{- end -}}
+          {{- end }}
+      {{ end }}
+  {{- end -}}

--- a/README.md
+++ b/README.md
@@ -40,3 +40,6 @@ No resources.
 
 ## Contribute
 
+Please use Pull requests to contribute.
+
+When a new Feature or Fix is ready to be released, create a new Github release and adhere to [Semantic Versioning 2.0.0](https://semver.org/lang/de/spec/v2.0.0.html).

--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 [![License](https://img.shields.io/github/license/qbeyond/terraform-module-template.svg)](https://github.com/qbeyond/terraform-module-template/blob/main/LICENSE)
 
 ----
+
+This is a template module. It just showcases how a module should look. This would be a short description of the module.
+
 <!-- BEGIN_TF_DOCS -->
 ## Usage
 
@@ -35,5 +38,5 @@ No resources.
 
 <!-- END_TF_DOCS -->
 
-# Contribute
+## Contribute
 

--- a/README.md
+++ b/README.md
@@ -4,31 +4,35 @@
 
 ----
 <!-- BEGIN_TF_DOCS -->
-Add a Short description of this module
+## Usage
+
+It's very easy to use!
+```hcl
+
+```
 
 ## Requirements
 
 No requirements.
 
-## Providers
+## Inputs
 
-No providers.
+No inputs.
+## Outputs
+
+No outputs.
+## Resource types
+
+No resources.
+
 
 ## Modules
 
 No modules.
-
-## Resources
+## Resources by Files
 
 No resources.
 
-## Inputs
-
-No inputs.
-
-## Outputs
-
-No outputs.
 <!-- END_TF_DOCS -->
 
 # Contribute

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,1 @@
-/**
- * Add a Short description of this module
- *
- * 
- */
+


### PR DESCRIPTION
# Description

I don't like the default configuration for some reasons:
 

## Showing Requirements and Providers

When writing non-root modules all used providers should also be in the required_providers block (see [directive](https://confluence.one4all.lan/display/AMS/Terraform+directive#Terraformdirective-Providers)). Therefore the Requirements and Providers should contain the same information for modules. For configuration it could be interesting to add Providers as soon as there are more information (like actual provider config) is exported. Otherwise also configuration should declare all providers as required.
 
Therefore I hid the entire Section.
 

## Listing all Resource Block

The default lists all resources including their names. For me as a user of a module, I want to know, what resources the configuration deploys. I don't care about the names, as they are most likely internal anyway. 
 
Therefore I added just a list of the resource types a module uses.
 

## Importance of Sections

As a user of a module I want to know what the module does (the description) and how to use it (examples). Then I want to know how to use it in detail and find out about Requirements and Inputs (most likely the required ones first) or Outputs. Then I have a look at the deployed Resource (resource types) in detail and analyse the used modules for more resources. 
When I want to contribute to the module or find how certain stuff is implemented I quickly want to know, where the resource in question is used (resources by files).
I came up with the structure, when reading the custom documentation from google cloud foundation modules.

# How Has This Been Tested?

- [x] Generated Documentation for empty module
- [x] Generated Documentation for module with configured resources, providers, variables and outputs

# Checklist:

- [x] I have run tests and documented them above
- [x] I have performed a self-review of my own code
- [x] I have updated the documentation
